### PR TITLE
fix TSV file keys

### DIFF
--- a/wh2/generate.py
+++ b/wh2/generate.py
@@ -96,7 +96,7 @@ class TWDBReaderImpl():
     self.head_rows.append(next(self.read_tsv))
     self.key_ids = {}
     i = 0
-    for key in self.head_rows[1]:
+    for key in self.head_rows[0]:
         self.key_ids[key] = i
         i = i + 1
 


### PR DESCRIPTION
When running the script, the wrong row of the TSV file is selected as the key, crushing on the first attempt to read from it due to a key mismatch.
![mod fix](https://user-images.githubusercontent.com/23134197/187059960-465ab3b4-f170-49ce-bf93-1bb49e73d7d6.png)

This may be due to the order of the first 2 rows being reversed in later versions of RPFM, I'm running v3.0.12
![mod fix2](https://user-images.githubusercontent.com/23134197/187060004-7f5e83ee-d18b-4ab2-9432-e3687d42f5cf.png)
